### PR TITLE
Clonar repo, modificar un commit y readme.md

### DIFF
--- a/GitHub.txt
+++ b/GitHub.txt
@@ -27,3 +27,22 @@ Si se desea cargar un repositorio de Git local a GitHub entonces se deben seguir
   $git push origin master
 
 Y listo, ya deberían de estar actualizados tanto el repositorio local como el de GitHub (:
+
+**Clonar un repositorio de Git**
+
+Al momento de clonar un repositorio se crea una versión local actualizada local y nos podemos ahorrar el comando
+del paso 3 "agregar un origin en el repositorio local" pues se crea de manera automática.
+
+1. En GitHub ir al repositorio de interés y dar click en "fork". Esto creará una copia actualizada del repositorio
+que es importante destacar, es DIFERENTE del repositorio original, por lo que los pull y push serán entre la versión local
+y MI copia (o fork) de GitHub.
+
+2. Ir al fork del proyecto y dar click en code/https url ó SSH url
+
+3. Comando para clonar un repositorio.
+    $git clone <url>
+
+Listo (: ahora ya tienes tu propia copia del repositorio.
+
+Para hacer aportaciones al repositorio original consultar el documento "Flujo-de-trabajo-profesional.txt" 
+en el apartado **Pull request sin ser colaborador**. Esta aportación es una explicación detallada del paso número 2.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # RepasoGityGitHub
 Este es un repaso de la clase de Git y GitHub de Platzi
-
-Hola, soy un nuevo colaborador (: 

--- a/apuntes.txt
+++ b/apuntes.txt
@@ -47,6 +47,11 @@ Los archivos que no son nuevos (ya existen commits previos) se pueden agregar al
 al mismo tiempo con el comando 
     $git commit -am "descripcion"
 
+**Modificar el mensaje de un commit**
+Para modificar la descripción del último commit se ejecuta el siguiente comando
+    $git commit --amend
+Esto abrira un editor de texto en consola y se podrá realizar el cambio pertinentes
+
 **Remover un archivo del stage**
 En caso de que se desee eliminar un archivo del stage muy posiblemente porque se cometió un error, se ejecuta
     $git restore --staged  "nombre.extension"


### PR DESCRIPTION
Se agregaron las instrucciones para clonar un repositorio (Fork) en el archivo GitHub.txt

Se agregó el comando para modificar la descripción del último commit en el archivo apuntes.txt y  se eliminó el mensaje del último colaborador en el archivo readme, debido a que no iba ahí.